### PR TITLE
I have added the missing bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "openlayers3",
+  "version": "3.4.0",
+  "main": [
+  "./build/ol.js",  
+  "./build/ol.css"
+  ],
+  "ignore": [
+    "./build/ol.ext/*.*",
+	"./build/timestamps/*.*",
+    "info.json",
+    "npm-install-timestamp",
+    "ol.js.map",
+    "ol-debug.js"
+  ]
+}


### PR DESCRIPTION
This file is needed if some automated system like gulp task is used. The reason we need this is when wiredep package is used it fails to find the main fails to ultimately inject them into the index file.
